### PR TITLE
fix wrong JsonPropertyNameAttribute on CashInCallback.Type

### DIFF
--- a/src/CashIn/Models/Callback/CashInCallback.cs
+++ b/src/CashIn/Models/Callback/CashInCallback.cs
@@ -10,7 +10,7 @@ namespace X.Paymob.CashIn.Models.Callback;
 [PublicAPI]
 public class CashInCallback {
     /// <summary>See: <see cref="CashInCallbackTypes"/>.</summary>
-    [JsonPropertyName("json")]
+    [JsonPropertyName("type")]
     public string? Type { get; init; }
 
     /// <summary>


### PR DESCRIPTION
`CashInCallback.Type` has `[JsonPropertyName("json")]` but it should be `[JsonPropertyName("type")]`